### PR TITLE
address security vulnerability in cryptography lib

### DIFF
--- a/WebPortal/requirement.txt
+++ b/WebPortal/requirement.txt
@@ -4,7 +4,7 @@ certifi==2018.11.29
 chardet==3.0.4
 Click==7.0
 colorama==0.3.7
-cryptography==2.1.4
+cryptography==2.6.1
 enum34==1.1.6
 Flask==1.0.2
 Flask-Cors==3.0.7


### PR DESCRIPTION
CVE-2018-10903
More information
high severity
Vulnerable versions: >= 1.9.0, < 2.3
Patched version: 2.3

A flaw was found in python-cryptography versions between >=1.9.0 and <2.3. The finalize_with_tag API did not enforce a minimum tag length. If a user did not validate the input length prior to passing it to finalize_with_tag an attacker could craft an invalid payload with a shortened tag (e.g. 1 byte) such that they would have a 1 in 256 chance of passing the MAC check. GCM tag forgeries can cause key leakage.